### PR TITLE
Update IREG.ttl

### DIFF
--- a/archive/catalogues/democat/IREG.ttl
+++ b/archive/catalogues/democat/IREG.ttl
@@ -1,7 +1,7 @@
 PREFIX dcat: <http://www.w3.org/ns/dcat#>
 PREFIX dcterms: <http://purl.org/dc/terms/>
 PREFIX geo: <http://www.opengis.net/ont/geosparql#>
-PREFIX idnrole: <https://data.idnau.org/pid/vocab/idn-role-codes/>
+PREFIX datarole: <https://linked.data.gov.au/def/data-roles/>
 PREFIX idnaccess: <http://idn.kurrawong.net/vocab/data-access-rights/>
 PREFIX idntheme: <http://idn.kurrawong.net/vocab/idn-th/>
 PREFIX iso: <http://def.isotc211.org/iso19115/-1/2018/CitationAndResponsiblePartyInformation/code/CI_RoleCode/>
@@ -47,7 +47,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
             prov:agent <https://linked.data.gov.au/org/abs>
         ] ,
         [
-            dcat:hadRole idnrole:subjectAgentRepresentatitve ;
+            dcat:hadRole datarole:subjectAgentRepresentatitve ;
             prov:agent <https://data.idnau.org/pid/org/abs-catsis>
         ] ;
     skos:note """Added this to show the full ASGS Indigenous hierarchy -- minimal description for now.

--- a/archive/catalogues/democat/IREG.ttl
+++ b/archive/catalogues/democat/IREG.ttl
@@ -2,7 +2,7 @@ PREFIX dcat: <http://www.w3.org/ns/dcat#>
 PREFIX dcterms: <http://purl.org/dc/terms/>
 PREFIX geo: <http://www.opengis.net/ont/geosparql#>
 PREFIX datarole: <https://linked.data.gov.au/def/data-roles/>
-PREFIX idnaccess: <http://idn.kurrawong.net/vocab/data-access-rights/>
+PREFIX dataaccess: <http://linked.data.gov.au/def/data-access-rights/>
 PREFIX idntheme: <http://idn.kurrawong.net/vocab/idn-th/>
 PREFIX iso: <http://def.isotc211.org/iso19115/-1/2018/CitationAndResponsiblePartyInformation/code/CI_RoleCode/>
 PREFIX prov: <http://www.w3.org/ns/prov#>
@@ -31,7 +31,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
             prov:startedAtTime "2021"^^xsd:gYear
         ] ;
     dcterms:type <http://www.opengis.net/ont/geosparql#FeatureCollection> ;
-    dcterms:accessRights idnaccess:open ;
+    dcterms:accessRights dataaccess:open ;
     dcat:accessURL "https://linked.data.gov.au/dataset/asgsed3/ILOC"^^xsd:anyURI ;
     dcat:theme
         idntheme:indigenous-demographics ,

--- a/data/_background/idn-role-codes-labels.ttl
+++ b/data/_background/idn-role-codes-labels.ttl
@@ -100,3 +100,29 @@ PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
     rdfs:label "Indigenous Data Network" ;
 .
 
+<https://linked.data.gov.au/def/data-roles>
+    rdfs:label "Data Role"@en ;
+.
+
+<https://linked.data.gov.au/def/data-roles/subjectAgent>
+    rdfs:label "subject agent"@en ;
+.
+
+<https://linked.data.gov.au/def/data-roles/subjectAgentRepresentative>
+    rdfs:label "subject agent representative"@en ;
+.
+
+<https://linked.data.gov.au/def/data-roles/pointOfContact>
+    rdfs:label "point of contact"@en ;
+.
+
+<https://linked.data.gov.au/def/data-roles/custodian>
+    rdfs:label "custodian"@en ;
+.
+
+<https://linked.data.gov.au/def/data-roles/owner>
+    rdfs:label "owner"@en ;
+.
+
+
+

--- a/data/catalogues/democat/IARE.ttl
+++ b/data/catalogues/democat/IARE.ttl
@@ -1,8 +1,8 @@
 PREFIX dcat: <http://www.w3.org/ns/dcat#>
 PREFIX dcterms: <http://purl.org/dc/terms/>
 PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
-PREFIX idnrole: <https://data.idnau.org/pid/vocab/idn-role-codes/>
-PREFIX idnaccess: <http://idn.kurrawong.net/vocab/data-access-rights/>
+PREFIX datarole: <https://linked.data.gov.au/def/data-roles/>
+PREFIX dataaccess: <http://linked.data.gov.au/def/data-access-rights/>
 PREFIX idntheme: <http://idn.kurrawong.net/vocab/idn-th/>
 PREFIX iso: <http://def.isotc211.org/iso19115/-1/2018/CitationAndResponsiblePartyInformation/code/CI_RoleCode/>
 PREFIX prov: <http://www.w3.org/ns/prov#>
@@ -29,7 +29,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
             prov:startedAtTime "2021"^^xsd:gYear
         ] ;
     dcterms:type <http://www.opengis.net/ont/geosparql#FeatureCollection> ;
-    dcterms:accessRights idnaccess:open ;
+    dcterms:accessRights dataaccess:open ;
     dcat:accessURL "https://linked.data.gov.au/dataset/asgsed3/ILOC"^^xsd:anyURI ;
     dcat:theme
         idntheme:indigenous-demographics ,
@@ -45,7 +45,7 @@ PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
             prov:agent <https://linked.data.gov.au/org/abs>
         ] ,
         [
-            dcat:hadRole idnrole:subjectAgentRepresentatitve ;
+            dcat:hadRole datarole:subjectAgentRepresentatitve ;
             prov:agent <https://data.idnau.org/pid/org/abs-catsis>
         ] ;
     skos:note """Added this to show the full ASGS Indigenous hierarchy -- minimal description for now.

--- a/data/system/catalog-system.ttl
+++ b/data/system/catalog-system.ttl
@@ -1,7 +1,7 @@
 PREFIX dcat: <http://www.w3.org/ns/dcat#>
 PREFIX dcterms: <http://purl.org/dc/terms/>
 PREFIX idnth: <https://data.idnau.org/pid/vocab/idn-th/>
-PREFIX idnroles: <https://data.idnau.org/pid/vocab/idn-role-codes/>
+PREFIX dataroles: <https://linked.data.gov.au/def/data-roles/>
 PREFIX isoroles: <http://def.isotc211.org/iso19115/-1/2018/CitationAndResponsiblePartyInformation/code/CI_RoleCode/>
 PREFIX owl: <http://www.w3.org/2002/07/owl#>
 PREFIX prov: <http://www.w3.org/ns/prov#>


### PR DESCRIPTION
Updating some lingering refs to unmanaged IRIs, mostly data role and data access vocabs.

Updating idnrole prefix to align with linked.data.gov.au manifestation. prefix is now datarole (drole is used also)
